### PR TITLE
add cgexec call to start processes using cgroup cpu:cpulimited

### DIFF
--- a/workersctl
+++ b/workersctl
@@ -39,7 +39,7 @@ start() {
 		exit 1
 	fi
 	LOGFILE=$LOGDIR/$HOST/worker.$HOST.log
-	CMD="$TQHOME/workers.rb -m $MQHOST -l $LOGFILE -p $PIDFILE"
+	CMD="cgexec -g cpu:cpulimited $TQHOME/workers.rb -m $MQHOST -l $LOGFILE -p $PIDFILE"
 	if [ "$TQUSER" = "$(whoami)" ]; then
 		$CMD
 	else


### PR DESCRIPTION
add call to `cgexec` to enable control of CPU utilization of the `task-queue` process hierarchy